### PR TITLE
Add streaming benchmark

### DIFF
--- a/bench/bench.hs
+++ b/bench/bench.hs
@@ -4,6 +4,7 @@ import Gauge
 import Data.List (foldl')
 import qualified Data.Vector as VB
 import qualified Data.Vector.Unboxed as VU
+import qualified Streaming.Prelude as Streaming
 import qualified Streamly
 import qualified Streamly.Prelude as Streamly
 import qualified Pipes
@@ -32,5 +33,8 @@ main = defaultMain
         runIdentity
           $ Streamly.foldl (+) 0 id
           $ (Streamly.each [1..high] :: Streamly.StreamT Identity Int)
+    , bench' "streaming" $ \high ->
+        runIdentity
+          $ Streaming.sum (Streaming.each [1..high])
     ]
   ]

--- a/package.yaml
+++ b/package.yaml
@@ -52,5 +52,6 @@ benchmarks:
     - gauge
     - pipes
     - streamly
+    - streaming
     - vector
     - zerem


### PR DESCRIPTION
Streaming comes the 2nd among streaming libraries after `conduit` on my machine:

```
benchmarked sum/zerem Identity
time                 96.15 μs   (95.52 μs .. 96.53 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 96.23 μs   (95.96 μs .. 96.49 μs)
std dev              886.2 ns   (756.9 ns .. 1.078 μs)
             
benchmarked sum/zerem ST
time                 95.98 μs   (95.34 μs .. 96.44 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 95.81 μs   (95.57 μs .. 96.05 μs)
std dev              858.4 ns   (748.3 ns .. 1.024 μs)
             
benchmarked sum/Prelude.sum
time                 95.27 μs   (94.80 μs .. 95.68 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 95.93 μs   (95.73 μs .. 96.16 μs)
std dev              740.2 ns   (602.0 ns .. 968.1 ns)
             
benchmarked sum/foldl' on lists
time                 95.88 μs   (95.53 μs .. 96.29 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 95.66 μs   (95.51 μs .. 95.85 μs)
std dev              576.4 ns   (465.0 ns .. 721.0 ns)
             
benchmarked sum/foldl' on boxed vector
time                 96.38 μs   (95.95 μs .. 96.96 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 96.16 μs   (95.97 μs .. 96.41 μs)
std dev              755.0 ns   (606.4 ns .. 975.0 ns)
             
benchmarked sum/foldl' on unboxed vector
time                 96.04 μs   (95.52 μs .. 96.52 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 95.61 μs   (95.39 μs .. 95.84 μs)
std dev              784.0 ns   (665.2 ns .. 917.9 ns)
             
benchmarked sum/conduit
time                 97.60 μs   (96.89 μs .. 98.28 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 98.68 μs   (98.03 μs .. 99.53 μs)
std dev              2.418 μs   (1.946 μs .. 3.039 μs)
variance introduced by outliers: 11% (moderately inflated)
             
benchmarked sum/pipes
time                 1.806 ms   (1.796 ms .. 1.821 ms)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 1.816 ms   (1.811 ms .. 1.823 ms)
std dev              19.99 μs   (16.59 μs .. 24.23 μs)
             
benchmarked sum/Streamly
time                 1.985 ms   (1.974 ms .. 1.994 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.988 ms   (1.982 ms .. 1.998 ms)
std dev              27.86 μs   (17.09 μs .. 50.33 μs)
             
benchmarked sum/streaming
time                 1.808 ms   (1.795 ms .. 1.819 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.784 ms   (1.778 ms .. 1.791 ms)
std dev              20.46 μs   (17.24 μs .. 24.25 μs)
```